### PR TITLE
Add links to event cards

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,11 +1,13 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
+import { ExternalLink, Youtube } from "lucide-react"
 
 // upcoming events
 const events = [
   {
     title: "Code N' Coffee Podcast",
     date: "Ongoing LIVE on YouTube",
+    url: "https://www.youtube.com/watch?v=6-IQhqESj8E&list=PLkWgPcG-GFhB3sSAf7dzUs_F3dQ19ihXR&index=1",
     description: "Code N' Coffee, is a series of byte-sized tech content aimed at Computer Science students presented to you by The Mozilla Campus Club of SLIIT. Don't miss out on the Tech insights and the latest of the tech and privacy world.",
     location: "Youtube - @sliitmozilla",
     time: "Every Week",
@@ -38,30 +40,56 @@ const pastEvents = [
   {
     title: "Bashaway 2024",
     image: "/assets/bashaway.jpg",
+    url: "https://www.facebook.com/share/p/1BGnzvHnXn/?mibextid=oFDknk",
+    url_label: "Check out the gallery!",
     description:
       "The 3rd iteration of Bashaway, an Inter-University Scripting competition organized by the SLIIT FOSS Community in collaboration with Mozilla Campus Club of SLIIT, SLIIT Women in FOSS, and Software Engineering Student Community was held in October 2024.",
   },
   {
     title: "Intro to Assembly Programming",
     image: "/assets/3.png",
+    url: "https://www.youtube.com/watch?v=p3pAHNgymXA",
     description:
       "The 3rd live tech session conducted by Seniru Pasan. Dive into the world of low-level programming! Exploring the fundamentals that power your devices, demystifying how software speaks to hardware.",
   },
   {
     title: "Utilizing AntDesign for quick UI Development",
     image: "/assets/2.png",
+    url: "https://www.youtube.com/watch?v=qfFaOkHoRVM",
     description:
       "The 2nd live tech session conducted by Russell Peiris. A session focusing on frontend and building clean and neat UIs",
   },
   {
     title: "Intro to Swift & SwiftUI",
     image: "/assets/1.png",
+    url: "https://www.youtube.com/watch?v=QZinHA1r4w0",
     description:
       "The 1st live tech session conducted by Nowen Kottage. Dive into iOS Development with the Introduction to Swift & SwiftUI: A sneak peek into UIKit!",
   },
 ]
 
 export default function Events() {
+
+  const getEventLinkText = (url?: string, label?: string) => {
+    if (!url) return
+    const icon = url.includes("youtube.com") ?
+      <Youtube className="mr-1" />
+      : <ExternalLink className="mr-1" />
+    const labelText = label || (url.includes("youtube.com") ? "Watch the session!" : "Check out!")
+
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex mt-3"
+      >
+        {icon}
+        {labelText}
+      </a>
+    )
+  }
+
   return (
     <div className="py-12">
       <div className="container mx-auto px-4">
@@ -79,6 +107,7 @@ export default function Events() {
                 <div className="space-y-2 text-sm text-gray-500">
                   <p>📍 {event.location}</p>
                   <p>🕒 {event.time}</p>
+                  {getEventLinkText(event.url)}
                 </div>
                 {/* <Button className="w-full mt-4">Register Now!</Button> */}
               </CardContent>
@@ -105,6 +134,7 @@ export default function Events() {
                 <div className="p-6">
                   <h3 className="text-xl font-bold mb-2 text-orange-600">{pastEvent.title}</h3>
                   <p className="text-gray-600">{pastEvent.description}</p>
+                  {getEventLinkText(pastEvent.url, pastEvent.url_label)}
                 </div>
               </div>
             ))}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,13 +1,16 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { ExternalLink, Youtube } from "lucide-react"
+import { ExternalLink, Youtube, MicVocal, LucideIcon } from "lucide-react"
+
 
 // upcoming events
 const events = [
   {
     title: "Code N' Coffee Podcast",
     date: "Ongoing LIVE on YouTube",
-    url: "https://www.youtube.com/watch?v=6-IQhqESj8E&list=PLkWgPcG-GFhB3sSAf7dzUs_F3dQ19ihXR&index=1",
+    url: "https://youtube.com/playlist?list=PLkWgPcG-GFhB3sSAf7dzUs_F3dQ19ihXR&si=aGi9UGwc3KmNcIHT",
+    urlLabel: "Catch the podcast!",
+    urlIcon: MicVocal,
     description: "Code N' Coffee, is a series of byte-sized tech content aimed at Computer Science students presented to you by The Mozilla Campus Club of SLIIT. Don't miss out on the Tech insights and the latest of the tech and privacy world.",
     location: "Youtube - @sliitmozilla",
     time: "Every Week",
@@ -41,7 +44,7 @@ const pastEvents = [
     title: "Bashaway 2024",
     image: "/assets/bashaway.jpg",
     url: "https://www.facebook.com/share/p/1BGnzvHnXn/?mibextid=oFDknk",
-    url_label: "Check out the gallery!",
+    urlLabel: "Check out the gallery!",
     description:
       "The 3rd iteration of Bashaway, an Inter-University Scripting competition organized by the SLIIT FOSS Community in collaboration with Mozilla Campus Club of SLIIT, SLIIT Women in FOSS, and Software Engineering Student Community was held in October 2024.",
   },
@@ -70,11 +73,14 @@ const pastEvents = [
 
 export default function Events() {
 
-  const getEventLinkText = (url?: string, label?: string) => {
-    if (!url) return
-    const icon = url.includes("youtube.com") ?
-      <Youtube className="mr-1" />
-      : <ExternalLink className="mr-1" />
+  const getEventLinkText = (url?: string, label?: string, UrlIcon?: LucideIcon) => {
+    if (!url) return null
+    const icon = UrlIcon 
+      ? <UrlIcon className="mr-1" />
+      : url.includes("youtube.com")
+        ? <Youtube className="mr-1" /> 
+        : <ExternalLink className="mr-1" />
+
     const labelText = label || (url.includes("youtube.com") ? "Watch the session!" : "Check out!")
 
     return (
@@ -107,7 +113,7 @@ export default function Events() {
                 <div className="space-y-2 text-sm text-gray-500">
                   <p>📍 {event.location}</p>
                   <p>🕒 {event.time}</p>
-                  {getEventLinkText(event.url)}
+                  {getEventLinkText(event.url, event.urlLabel, event.urlIcon)}
                 </div>
                 {/* <Button className="w-full mt-4">Register Now!</Button> */}
               </CardContent>
@@ -134,7 +140,7 @@ export default function Events() {
                 <div className="p-6">
                   <h3 className="text-xl font-bold mb-2 text-orange-600">{pastEvent.title}</h3>
                   <p className="text-gray-600">{pastEvent.description}</p>
-                  {getEventLinkText(pastEvent.url, pastEvent.url_label)}
+                  {getEventLinkText(pastEvent.url, pastEvent.urlLabel, pastEvent.urlIcon)}
                 </div>
               </div>
             ))}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { ExternalLink, Youtube, MicVocal, LucideIcon } from "lucide-react"
+import { ExternalLink, Youtube, Mic, LucideIcon } from "lucide-react"
 
 
 // upcoming events
@@ -10,7 +10,7 @@ const events = [
     date: "Ongoing LIVE on YouTube",
     url: "https://youtube.com/playlist?list=PLkWgPcG-GFhB3sSAf7dzUs_F3dQ19ihXR&si=aGi9UGwc3KmNcIHT",
     urlLabel: "Catch the podcast!",
-    urlIcon: MicVocal,
+    urlIcon: Mic,
     description: "Code N' Coffee, is a series of byte-sized tech content aimed at Computer Science students presented to you by The Mozilla Campus Club of SLIIT. Don't miss out on the Tech insights and the latest of the tech and privacy world.",
     location: "Youtube - @sliitmozilla",
     time: "Every Week",
@@ -76,10 +76,10 @@ export default function Events() {
   const getEventLinkText = (url?: string, label?: string, UrlIcon?: LucideIcon) => {
     if (!url) return null
     const icon = UrlIcon 
-      ? <UrlIcon className="mr-1" />
+      ? <UrlIcon className="mr-1 w-4 h-4" />
       : url.includes("youtube.com")
-        ? <Youtube className="mr-1" /> 
-        : <ExternalLink className="mr-1" />
+        ? <Youtube className="mr-1 w-4 h-4" /> 
+        : <ExternalLink className="mr-1 w-4 h-4" />
 
     const labelText = label || (url.includes("youtube.com") ? "Watch the session!" : "Check out!")
 
@@ -88,7 +88,7 @@ export default function Events() {
         href={url}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex mt-3"
+        className="flex items-center mt-3"
       >
         {icon}
         {labelText}


### PR DESCRIPTION
Events can now display their relevant links
![image](https://github.com/user-attachments/assets/5207c375-6f4b-4f22-a152-e97847d1e405)

I made it in a way where we can add custom labels to links, or stay with the defaults ("Check out!"  or "Watch the session!" for youtube links).
For youtube links it will display youtube icon


```js
const event = {
    // ...
    url: "https://url.com",
    url_label: "Custom url label here, if any",
  // ...
}
```

This PR closes #12 