### PR TITLE
Fix build errors

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -2,9 +2,20 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button"
 import { ExternalLink, Youtube, Mic, LucideIcon } from "lucide-react"
 
+type Event = {
+  title: string,
+  image: string,
+  date: string,
+  time: string,
+  location :string,
+  url: string,
+  urlLabel: string,
+  urlIcon: LucideIcon,
+  description: string
+}
 
 // upcoming events
-const events = [
+const events: Partial<Event>[] = [
   {
     title: "Code N' Coffee Podcast",
     date: "Ongoing LIVE on YouTube",
@@ -39,7 +50,7 @@ const events = [
 ]
 
 // past events data
-const pastEvents = [
+const pastEvents: Partial<Event>[] = [
   {
     title: "Bashaway 2024",
     image: "/assets/bashaway.jpg",


### PR DESCRIPTION
- property `urlIcon` not existing

```
./app/events/page.tsx:143:82
Type error: Property 'urlIcon' does not exist on type '{ title: string; image: string; url: string; urlLabel: string; description: string; } | { title: string; image: string; url: string; description: string; urlLabel?: undefined; }'.
  Property 'urlIcon' does not exist on type '{ title: string; image: string; url: string; urlLabel: string; description: string; }'.

  141 |                   <h3 className="text-xl font-bold mb-2 text-orange-600">{pastEvent.title}</h3>
  142 |                   <p className="text-gray-600">{pastEvent.description}</p>
> 143 |                   {getEventLinkText(pastEvent.url, pastEvent.urlLabel, pastEvent.urlIcon)}
      |                                                                                  ^
  144 |                 </div>
  145 |               </div>
  146 |             ))}
```

This PR fixes a buld error introduced by the PR #12 by making `Event` type `Partial`