### PR TITLE
Fix fox running animation filling the entire screen

### DIFF
--- a/app/SplashScreen.tsx
+++ b/app/SplashScreen.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import Loading from "./loading"
 
 export function SplashScreen({ children }: { children: React.ReactNode }) {
   const [isLoading, setIsLoading] = useState(true)
@@ -16,16 +17,7 @@ export function SplashScreen({ children }: { children: React.ReactNode }) {
 
   if (isLoading) {
     // Show loading screen
-    return (
-      <div className="fixed inset-0 flex flex-col items-center justify-center bg-black text-white z-[999999]">
-        <h2 className="text-xl font-semibold mb-4">Loading...</h2>
-        <img
-          src="/assets/running-fox.gif"
-          alt="Loading..."
-          className="w-32 h-auto"
-        />
-      </div>
-    )
+    return <Loading />
   }
 
   return <>{children}</>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,12 +25,12 @@ export default function RootLayout({
       <body className={`${inter.className} antialiased`} suppressHydrationWarning>
         <div className="min-h-screen flex flex-col overflow-x-hidden">
           <Navbar />
-
-          <FoxAnimations />
-
-          <main className="flex-1">
-            {children}
-          </main>
+          <SplashScreen>
+            <FoxAnimations />
+            <main className="flex-1">
+              {children}
+            </main>
+          </SplashScreen>
           
           <Footer />
         </div>


### PR DESCRIPTION
This PR is related to and closes #25. With this PR, the fox-running animation will no longer fill the entire screen upon a hard reload.
I also replaced the content in `SplashScreen` with the unused `<Loading />` component. Let me know if I should revert or change that one.

