### PR TITLE
fix: update redirect to past term link (#37)

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -65,9 +65,14 @@ export function Navbar() {
               hover:text-black
             "
           >
-            <Link href="/join-us" className="w-full h-full block">
-              Join SLIIT Mozilla!
-            </Link>
+          <a
+            href="https://links.sliitmozilla.org/join"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="w-full h-full block"
+          >
+            Join SLIIT Mozilla!
+          </a>
           </Button>
         </div>
 
@@ -120,9 +125,14 @@ export function Navbar() {
               hover:text-black
             "
           >
-            <Link href="/join-us" className="w-full h-full block">
-              Join SLIIT Mozilla!
-            </Link>
+          <a
+            href="https://links.sliitmozilla.org/join"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="w-full h-full block"
+          >
+            Join SLIIT Mozilla!
+          </a>
           </Button>
           <hr />
         </div>


### PR DESCRIPTION
This PR updates the redirect on the homepage to point to the past term page.

The previous implementation was replaced to follow the instructions provided in issue #37.

Closes #37