### PR TITLE
feat: add Discord section to footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,5 +1,13 @@
 import Link from "next/link"
-import { Facebook, Twitter, Instagram, Github, Linkedin, Youtube, MessageCircle } from "lucide-react"
+import {
+  Facebook,
+  Twitter,
+  Instagram,
+  Github,
+  Linkedin,
+  Youtube,
+  MessageCircle,
+} from "lucide-react"
 
 export function Footer() {
   return (
@@ -83,7 +91,9 @@ export function Footer() {
                 <Linkedin className="h-5 w-5" />
               </Link>
               <Link
-                href="https://discord.gg/EqEUDnmkDZ" className="hover:text-primary block lg:hidden">
+                href="https://discord.gg/EqEUDnmkDZ"
+                className="hover:text-primary block lg:hidden"
+              >
                 <MessageCircle className="w-5 h-5" />
               </Link>
             </div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link"
-import { Facebook, Twitter, Instagram, Github, Linkedin, Youtube } from "lucide-react"
+import { Facebook, Twitter, Instagram, Github, Linkedin, Youtube, MessageCircle } from "lucide-react"
 
 export function Footer() {
   return (
@@ -55,7 +55,7 @@ export function Footer() {
             </div>
           </div>
 
-          <div className="flex flex-col items-center">
+          <div className="flex flex-col">
             <h4 className="font-semibold mb-4">Follow Us on Socials!</h4>
             <div className="flex space-x-4">
               <Link href="https://www.facebook.com/sliitmozilla" className="hover:text-primary">
@@ -81,6 +81,19 @@ export function Footer() {
                 className="hover:text-primary"
               >
                 <Linkedin className="h-5 w-5" />
+              </Link>
+              <Link
+                href="https://discord.gg/EqEUDnmkDZ" className="hover:text-primary block lg:hidden">
+                <MessageCircle className="w-5 h-5" />
+              </Link>
+            </div>
+            <div className="mt-6 hidden lg:block">
+              <Link
+                href="https://discord.gg/EqEUDnmkDZ"
+                target="_blank"
+                className="text-white bg-indigo-600 hover:bg-indigo-700 px-4 py-2 rounded transition-colors"
+              >
+                Join Us on Discord
               </Link>
             </div>
           </div>


### PR DESCRIPTION
Fixes #58 
This pull request updates the `Footer` component to improve the visibility and accessibility of the Discord community link, especially across different device sizes. The changes also include minor layout adjustments for better alignment.

**Discord link integration and layout improvements:**

* Added the `MessageCircle` icon from `lucide-react` and included a Discord link in the social icons row, visible only on small screens (`block lg:hidden`). [[1]](diffhunk://#diff-4f34a078049f572f5ebcdf8a3b771ce47c64ec9808cf3acf95a04e1ab72c214dL2-R2) [[2]](diffhunk://#diff-4f34a078049f572f5ebcdf8a3b771ce47c64ec9808cf3acf95a04e1ab72c214dR85-R97)
* Added a prominent "Join Us on Discord" button for large screens, styled for visibility and placed below the social icons.
* Updated the container for the social section to remove `items-center` alignment, allowing for improved layout flexibility.

<img width="1343" height="606" alt="Screenshot (1084)" src="https://github.com/user-attachments/assets/ec496719-d1ec-4580-b5ea-0abdf3494d07" />
