### PR TITLE
feat: replace Community section with Awards and Prizes

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,14 +70,19 @@ export default function Home() {
               </p>
             </div>
 
-            <div className="bg-white p-6 rounded-lg shadow-sm transition-all duration-300 hover:bg-orange-50 hover:shadow-md cursor-pointer">
+            <a
+              href="https://certify.sliitmozilla.org"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-white p-6 rounded-lg shadow-sm transition-all duration-300 hover:bg-orange-50 hover:shadow-md cursor-pointer block"
+            >
               <span className="text-orange-600 text-2xl block text-left mb-2">⁕</span>
-              <h3 className="text-orange-600 font-bold mb-2">Community</h3>
+              <h3 className="text-orange-600 font-bold mb-2">Awards and Prizes</h3>
               <p className="text-gray-600">
-                Engage with a supportive network of peers, mentors, and tech enthusiasts eager to
-                share knowledge.
+                Earn recognition through certificates and awards for your contributions and
+                achievements.
               </p>
-            </div>
+            </a>
 
             <div className="bg-white p-6 rounded-lg shadow-sm transition-all duration-300 hover:bg-orange-50 hover:shadow-md cursor-pointer">
               <span className="text-orange-600 text-2xl block text-left mb-2">⁕</span>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -81,6 +81,15 @@ export default function Home() {
               <p className="text-gray-600">
                 Earn recognition through certificates and awards for your contributions and
                 achievements.
+                <br />
+                <a
+                  href="https://certify.sliitmozilla.org"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-orange-500 underline font-semibold text-sm"
+                >
+                  Go to Certify Site
+                </a>
               </p>
             </a>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unescaped-entities */
 import { MovingBanner } from "@/components/ui/moving-banner"
 import SenderInit from "@/components/ui/sender-init"
-import { Code2, Users, Rocket, Brain } from "lucide-react"
+import { Code2, Users, Rocket, Brain, ExternalLink } from "lucide-react"
 
 export default function Home() {
   const senderFormId = process.env.NEXT_PUBLIC_SENDER_FORM_ID
@@ -70,28 +70,23 @@ export default function Home() {
               </p>
             </div>
 
-            <a
-              href="https://certify.sliitmozilla.org"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="bg-white p-6 rounded-lg shadow-sm transition-all duration-300 hover:bg-orange-50 hover:shadow-md cursor-pointer block"
-            >
+            <div className="bg-white p-6 rounded-lg shadow-sm transition-all duration-300 hover:bg-orange-50 hover:shadow-md cursor-pointer">
               <span className="text-orange-600 text-2xl block text-left mb-2">⁕</span>
               <h3 className="text-orange-600 font-bold mb-2">Awards and Prizes</h3>
               <p className="text-gray-600">
                 Earn recognition through certificates and awards for your contributions and
                 achievements.
-                <br />
-                <a
-                  href="https://certify.sliitmozilla.org"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-orange-500 underline font-semibold text-sm"
-                >
-                  Go to Certify Site
-                </a>
               </p>
-            </a>
+              <a
+                href="https://certify.sliitmozilla.org"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-orange-500 underline font-semibold text-sm inline-flex items-center gap-1 mt-3"
+              >
+                Go to Certify Site
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </div>
 
             <div className="bg-white p-6 rounded-lg shadow-sm transition-all duration-300 hover:bg-orange-50 hover:shadow-md cursor-pointer">
               <span className="text-orange-600 text-2xl block text-left mb-2">⁕</span>


### PR DESCRIPTION
feat: replace Community section with Awards and Prizes #61

- Replace Community card with Awards and Prizes in "Why Join Us" section
- Add clickable link to certify.sliitmozilla.org

Before:
<img width="398" height="160" alt="image" src="https://github.com/user-attachments/assets/c2f7f9d7-45bd-4591-ae71-7de2ddf3233b" />
After:
<img width="710" height="271" alt="image" src="https://github.com/user-attachments/assets/29808656-3312-46ab-a939-5b015fec9985" />
