### PR TITLE
feat: add home link to navbar

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -43,6 +43,9 @@ export function Navbar() {
 
         {/* --- Desktop Nav Links --- */}
         <div className="hidden md:flex items-center space-x-6">
+          <NavLink href="/" active={isActive("/")}>
+            Home
+          </NavLink>
           <NavLink href="/about" active={isActive("/about")}>
             About
           </NavLink>
@@ -96,6 +99,9 @@ export function Navbar() {
         `}
       >
         <div className="flex flex-col space-y-4 text-left">
+          <NavLinkMobile href="/" active={isActive("/")} closeMenu={toggleMenu}>
+            Home
+          </NavLinkMobile>
           <NavLinkMobile href="/about" active={isActive("/about")} closeMenu={toggleMenu}>
             About
           </NavLinkMobile>


### PR DESCRIPTION
closes #71 

feat: add home link to navbar

<img width="340" height="100" alt="image" src="https://github.com/user-attachments/assets/948a20ed-01ee-4b6f-ae13-afd3bc899692" />

<img width="424" height="248" alt="image" src="https://github.com/user-attachments/assets/2248cc38-70da-4c32-a9c7-327d760834ae" />



- [x] Code runs locally without errors  
- [x] Code formatted using Prettier (`npm run format`)  
- [x] Branch is up to date with `main`  
- [x] Commit messages follow the conventional format  
- [x] Run `npm run prepare` to ensure pre-commit hooks (linting and formatting) are installed
- [x] Issue is assigned to you before submitting a PR  

```bash
> nextjs@0.1.0 format:check
> prettier --check "app/**/*.{js,ts,jsx,tsx,json,css,md}" "components/**/*.{js,ts,jsx,tsx,json,css,md}" "data/**/*.{js,ts,jsx,tsx,json,css,md}" "hooks/**/*.{js,ts,jsx,tsx,json,css,md}" "lib/**/*.{js,ts,jsx,tsx,json,css,md}"

Checking formatting...
All matched files use Prettier code style!
```
```bash
# eslint old error not relevant to this pr
./components/Navbar.tsx
41:11  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
```